### PR TITLE
Adding service version logging

### DIFF
--- a/fastly.toml
+++ b/fastly.toml
@@ -6,3 +6,7 @@ description = "A basic starter kit that demonstrates routing, simple synthetic r
 language = "go"
 manifest_version = 2
 name = "Default starter for Go"
+service_id = ""
+
+[scripts]
+  build = "tinygo build -target=wasi -gc=conservative -o bin/main.wasm ./"

--- a/fastly.toml
+++ b/fastly.toml
@@ -6,7 +6,3 @@ description = "A basic starter kit that demonstrates routing, simple synthetic r
 language = "go"
 manifest_version = 2
 name = "Default starter for Go"
-service_id = ""
-
-[scripts]
-  build = "tinygo build -target=wasi -gc=conservative -o bin/main.wasm ./"

--- a/main.go
+++ b/main.go
@@ -15,6 +15,8 @@ import (
 // synthetic responses.
 
 func main() {
+	// Log service version
+	fmt.Println("FASTLY_SERVICE_VERSION:", os.Getenv("FASTLY_SERVICE_VERSION"));
 	fsthttp.ServeFunc(func(ctx context.Context, w fsthttp.ResponseWriter, r *fsthttp.Request) {
 		// Filter requests that have unexpected methods.
 		if r.Method != "HEAD" && r.Method != "GET" {


### PR DESCRIPTION
Prints service version to console after running `fastly log-tail`. ([JIRA ticket](https://fastly.atlassian.net/browse/DEVLIB-856?atlOrigin=eyJpIjoiMDY0MmI0YThjZDVhNGE5NjljZjBiZGNjNTkzOWY2NDMiLCJwIjoiaiJ9))