### PR TITLE
Filtering requests by method without mentioning purge

### DIFF
--- a/main.go
+++ b/main.go
@@ -20,7 +20,7 @@ func main() {
 	
 	fsthttp.ServeFunc(func(ctx context.Context, w fsthttp.ResponseWriter, r *fsthttp.Request) {
 		// Filter requests that have unexpected methods.
-		if r.Method != "HEAD" && r.Method != "GET" && r.Method != "PURGE" {
+		if r.Method == "POST" || r.Method == "PUT" || r.Method == "PATCH" || r.Method == "DELETE" {
 			w.WriteHeader(fsthttp.StatusMethodNotAllowed)
 			fmt.Fprintf(w, "This method is not allowed\n")
 			return


### PR DESCRIPTION
Since we want to allow purge requests but not _encourage_ them, the method for filtering requests is being rewritten so as not to mention purging. The outcome of the method remains functionally the same, with HEAD, GET, and PURGE requests being let through and POST, PUT, PATCH, and DELETE being blocked. 