### PR TITLE
Make CI also update the Go SDK

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -16,6 +16,8 @@ jobs:
         check-latest: true
     - name: Setup Fastly CLI
       uses: fastly/compute-actions/setup@v5
+    - name: Update Go SDK
+      run: go get github.com/fastly/compute-sdk-go@latest
     - name: Build and test
       uses: fastly/compute-actions/build@v5
       with:


### PR DESCRIPTION
When using fastly compute init, the `post_init` script will run.

This won't run in CI, so we need to manually run that.