### PR TITLE
Use the //go:embed directive to include file

### DIFF
--- a/main.go
+++ b/main.go
@@ -1,12 +1,18 @@
 package main
 
 import (
+      _ "embed"
 	"context"
 	"fmt"
 	"os"
+        "bytes"
+        "io"
 
 	"github.com/fastly/compute-sdk-go/fsthttp"
 )
+
+//go:embed welcome-to-compute.html
+var welcomePage []byte
 
 // The entry point for your application.
 //
@@ -71,7 +77,7 @@ func main() {
 			// Send a default synthetic response.
 			w.Header().Set("Content-Type", "text/html; charset=utf-8")
 
-			fmt.Fprintln(w, `<iframe src="https://developer.fastly.com/compute-welcome" style="border:0; position: absolute; top: 0; left: 0; width: 100%; height: 100%"></iframe>`)
+			io.Copy(w, io.NopCloser(bytes.NewReader(welcomePage)))
 			return
 		}
 

--- a/welcome-to-compute.html
+++ b/welcome-to-compute.html
@@ -1,0 +1,30 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <meta http-equiv="x-ua-compatible" content="ie=edge" />
+    <meta
+      name="viewport"
+      content="width=device-width, initial-scale=1, shrink-to-fit=no"
+    />
+    <title>Welcome to Fastly Compute</title>
+    <link
+      rel="icon"
+      href="https://developer.fastly.com/favicon-32x32.png"
+      type="image/png"
+    />
+  </head>
+  <body>
+    <iframe
+      src="https://developer.fastly.com/compute-welcome"
+      style="
+        border: 0;
+        position: absolute;
+        top: 0;
+        left: 0;
+        width: 100%;
+        height: 100%;
+      "
+    ></iframe>
+  </body>
+</html>


### PR DESCRIPTION
This PR proposes a change to include html contents to this starter kit, primarily for the parity with other starter kits (both Rust and JS starter kit shows how one can embed arbitrary file to their wasm package). This is especially helpful for newbie or beginner in Go and/or Wasm. I confirmed this PR works with both Go and TinyGo. 

Please note that this directive was first introduced with [Go 1.16 release](https://go.dev/doc/go1.16) back in February 2021 - I'm not familiar with the compatibility policy of these starter kits, but it might be worth considering to add some notes for those who'd like to stick with older go environments.